### PR TITLE
Add support for rehype plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,14 @@ file source code. You could get these from the filesystem or from a remote
 database. If your MDX doesn't reference other files (or only imports things from
 `node_modules`), then you can omit this entirely.
 
-#### remarkPlugins
+#### remarkPlugins, rehypePlugins
 
 If you need to customize anything about the MDX compilation you can use remark
-plugins.
+and rehype plugins.
 
-NOTE: Specifying this will override the default value for frontmatter support so
-if you want to keep that, you'll need to include `remark-frontmatter` yourself.
+NOTE: Specifying `remarkPlugins` will override the default value for frontmatter
+support so if you want to keep that, you'll need to include `remark-frontmatter`
+within the `remarkPlugins` array yourself.
 
 #### esbuildOptions
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,10 @@ type BundleMDXOptions = {
    */
   remarkPlugins?: Array<unknown>
   /**
+   * The rehype plugins you want applied when compiling the MDX
+   */
+  rehypePlugins?: Array<unknown>
+  /**
    * This allows you to modify the built-in esbuild configuration. This can be
    * especially helpful for specifying the compilation target.
    *
@@ -94,6 +98,7 @@ async function bundleMDX(
     files = {},
     esbuildOptions = (options: ESBuildOptions) => options,
     remarkPlugins = [remarkFrontmatter],
+    rehypePlugins = [],
     globals = {},
   }: BundleMDXOptions = {},
 ) {
@@ -151,6 +156,7 @@ async function bundleMDX(
               // eslint-disable-next-line
               const result = (await createCompiler({
                 remarkPlugins,
+                rehypePlugins,
               }).process(contents)) as {contents: string}
               return {contents: result.contents, loader: 'jsx'}
             }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: add support for rehype plugins, parallel to the existing remark plugin support, as per the [standard mdx options pattern](https://github.com/mdx-js/mdx/blob/v1.6.22/packages/mdx/index.js#L12-L16)

<!-- Why are these changes necessary? -->

**Why**: some valuable markdown/MDX processing plugins are available only as rehype plugins, and some transformations are easier to implement in rehype

<!-- How were these changes implemented? -->

**How**: added the option to the `bundleMDX` function as well as the type information; passed it to `createCompiler`. Update relevant section of `README.md`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests -- could not find any tests for remarkPlugins, thus N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
