### PR TITLE
fix: with `cwd` the fake entry point can't exist

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -148,7 +148,7 @@ import Demo from './demo'
   assert.equal(
     error.message,
     `Build failed with 1 error:
-__mdx_bundler_fake_dir__/index.mdx:2:17: error: Could not resolve "./demo"`,
+__mdx_bundler_fake_dir__/_mdx_bundler_entry_point.mdx:2:17: error: Could not resolve "./demo"`,
   )
 })
 
@@ -188,7 +188,7 @@ import Demo from './demo.blah'
   assert.equal(
     error.message,
     `Build failed with 1 error:
-__mdx_bundler_fake_dir__/index.mdx:2:17: error: [plugin: JavaScript plugins] Invalid loader: "blah" (valid: js, jsx, ts, tsx, css, json, text, base64, dataurl, file, binary)`,
+__mdx_bundler_fake_dir__/_mdx_bundler_entry_point.mdx:2:17: error: [plugin: JavaScript plugins] Invalid loader: "blah" (valid: js, jsx, ts, tsx, css, json, text, base64, dataurl, file, binary)`,
   )
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,6 @@ import {NodeResolvePlugin} from '@esbuild-plugins/node-resolve'
 import {globalExternals} from '@fal-works/esbuild-plugin-global-externals'
 import dirnameMessedUp from './dirname-messed-up.cjs'
 
-if (dirnameMessedUp && !process.env.ESBUILD_BINARY_PATH) {
-  console.warn(
-    `mdx-bundler warning: esbuild maybe unable to find its binary, if your build fails you'll need to set ESBUILD_BINARY_PATH. Learn more: https://github.com/kentcdodds/mdx-bundler/blob/main/README.md#nextjs-esbuild-enoent`,
-  )
-}
-
 /**
  *
  * @param {string} mdxSource - A string of mdx source code
@@ -30,6 +24,12 @@ async function bundleMDX(
     cwd = path.join(process.cwd(), `__mdx_bundler_fake_dir__`),
   } = {},
 ) {
+  if (dirnameMessedUp && !process.env.ESBUILD_BINARY_PATH) {
+    console.warn(
+      `mdx-bundler warning: esbuild maybe unable to find its binary, if your build fails you'll need to set ESBUILD_BINARY_PATH. Learn more: https://github.com/kentcdodds/mdx-bundler/blob/main/README.md#nextjs-esbuild-enoent`,
+    )
+  }
+
   // xdm is a native ESM, and we're running in a CJS context. This is the
   // only way to import ESM within CJS
   const [{compile: compileMDX}, {default: xdmESBuild}] = await Promise.all([
@@ -39,7 +39,7 @@ async function bundleMDX(
   // extract the frontmatter
   const {data: frontmatter} = matter(mdxSource)
 
-  const entryPath = path.join(cwd, './index.mdx')
+  const entryPath = path.join(cwd, './_mdx_bundler_entry_point.mdx')
 
   /** @type Record<string, string> */
   const absoluteFiles = {[entryPath]: mdxSource}


### PR DESCRIPTION
Small PR this time.

When using `cwd` if the entrypoint exists on the disk esbuild will read it in first and fall over at not having a loader for MDX, although I though the xdm plugin was supposed to handle that.

I have all my posts as `_content/posts/SLUG/index.mdx` which was failing because `mdx-bundler` was using `cwd/index.mdx` as its entry point.

I've also moved the warning about the esbuild binary into the bundleMDX function as I was getting it `console.warn` me loads of times because its happening at require time before I've set the environment variable.