### PR TITLE
feat: allow `write` to be `true` so the file loader can be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 dist
 .DS_Store
+output/
 
 # these cause more harm than good
 # when working with contributors

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ should be installed as one of your project's `dependencies`:
 npm install --save mdx-bundler
 ```
 
+One of mdx-bundler's the dependancies requires a working [node-gyp](node-gyp) setup
+to be able to install correctly.
+
 ## Usage
 
 ```typescript
@@ -685,4 +688,5 @@ MIT
 [bugs]: https://github.com/kentcdodds/mdx-bundler/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Acreated-desc+label%3Abug
 [requests]: https://github.com/kentcdodds/mdx-bundler/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Aenhancement
 [good-first-issue]: https://github.com/kentcdodds/mdx-bundler/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Aenhancement+label%3A%22good+first+issue%22
+[node-gyp]: https://github.com/nodejs/node-gyp#installation
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -481,6 +481,67 @@ export const exampleImage = 'https://example.com/image.jpg'
 <img src={exampleImage} alt="Image alt text" />
 ```
 
+### Image Bundling
+
+With the [cwd](#cwd) and the remark plugin [remark-mdx-images](https://www.npmjs.com/package/remark-mdx-images)
+you can bundle images in your mdx!
+
+There are two loaders in esbuild that can be used here. The easiest is `dataurl`
+which outputs the images as inline data urls in the returned code.
+
+```js
+import {remarkMdxImages} from 'remark-mdx-images'
+
+const {code} = await bundleMDX(mdxSource, {
+  cwd: '/users/you/site/_content/pages',
+  xdmOptions: (vFile, options) => {
+    options.remarkPlugins = [remarkMdxImages]
+
+    return options
+  },
+  esbuildOptions: options => {
+    options.loader = {
+      ...options.loader,
+      '.png': 'dataurl'
+    }
+
+    return options
+  }
+})
+```
+
+The `file` loader requires a little more configuration to get working. With the
+`file` loader your images are copied to the output directory so esbuild needs
+to be set to write files and needs to know where to put them plus the url of
+the folder to be used in image sources.
+
+```js
+const {code} = await bundleMDX(mdxSource, {
+  cwd: '/users/you/site/_content/pages',
+  xdmOptions: (vFile, options) => {
+    options.remarkPlugins = [remarkMdxImages]
+
+    return options
+  },
+  esbuildOptions: options => {
+    // Set the `outdir` to your public directory.
+    options.outdir = '/users/you/site/public/img'
+    options.loader = {
+      ...options.loader,
+      // Tell esbuild to use the `file` loader for pngs
+      '.png': 'file'
+    }
+    // Set the public path to /img/ so image sources start /img/
+    options.publicPath = '/img/'
+
+    // Set write to true so that esbuild will output the files.
+    options.write = true
+
+    return options
+  }
+})
+```
+
 ### Known Issues
 
 #### Cloudflare Workers

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ should be installed as one of your project's `dependencies`:
 npm install --save mdx-bundler
 ```
 
-One of mdx-bundler's the dependancies requires a working [node-gyp](node-gyp) setup
+One of mdx-bundler's dependancies requires a working [node-gyp][node-gyp] setup
 to be able to install correctly.
 
 ## Usage
@@ -486,8 +486,9 @@ export const exampleImage = 'https://example.com/image.jpg'
 
 ### Image Bundling
 
-With the [cwd](#cwd) and the remark plugin [remark-mdx-images](https://www.npmjs.com/package/remark-mdx-images)
-you can bundle images in your mdx!
+With the [cwd](#cwd) and the remark plugin
+[remark-mdx-images](https://www.npmjs.com/package/remark-mdx-images) you can
+bundle images in your mdx!
 
 There are two loaders in esbuild that can be used here. The easiest is `dataurl`
 which outputs the images as inline data urls in the returned code.
@@ -505,18 +506,18 @@ const {code} = await bundleMDX(mdxSource, {
   esbuildOptions: options => {
     options.loader = {
       ...options.loader,
-      '.png': 'dataurl'
+      '.png': 'dataurl',
     }
 
     return options
-  }
+  },
 })
 ```
 
 The `file` loader requires a little more configuration to get working. With the
-`file` loader your images are copied to the output directory so esbuild needs
-to be set to write files and needs to know where to put them plus the url of
-the folder to be used in image sources.
+`file` loader your images are copied to the output directory so esbuild needs to
+be set to write files and needs to know where to put them plus the url of the
+folder to be used in image sources.
 
 ```js
 const {code} = await bundleMDX(mdxSource, {
@@ -532,7 +533,7 @@ const {code} = await bundleMDX(mdxSource, {
     options.loader = {
       ...options.loader,
       // Tell esbuild to use the `file` loader for pngs
-      '.png': 'file'
+      '.png': 'file',
     }
     // Set the public path to /img/ so image sources start /img/
     options.publicPath = '/img/'
@@ -541,7 +542,7 @@ const {code} = await bundleMDX(mdxSource, {
     options.write = true
 
     return options
-  }
+  },
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.13.17",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@fal-works/esbuild-plugin-global-externals": "^2.1.1",
-    "esbuild": "^0.11.15",
+    "esbuild": "^0.11.16",
     "gray-matter": "^4.0.3",
     "jsdom": "^16.5.3",
     "remark-frontmatter": "^3.0.0",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -5,6 +5,7 @@ import React from 'react'
 import rtl from '@testing-library/react'
 import leftPad from 'left-pad'
 import {remarkMdxImages} from 'remark-mdx-images'
+import path from 'path'
 import {bundleMDX} from '../index.js'
 import {getMDXComponent} from '../client.js'
 
@@ -290,6 +291,64 @@ import {Sample} from './other/sample-component'
   assert.match(
     container.innerHTML,
     'img alt="A Sample Image" src="data:image/png',
+  )
+})
+
+test('should output assets', async () => {
+  const mdxSource = `
+# Sample Post
+
+![Sample Image](./other/150.png)
+  `.trim()
+
+  const {code} = await bundleMDX(mdxSource, {
+    cwd: process.cwd(),
+    xdmOptions: (vFile, options) => {
+      options.remarkPlugins = [remarkMdxImages]
+
+      return options
+    },
+    esbuildOptions: options => {
+      options.outdir = path.join(process.cwd(), 'output')
+      options.loader = {
+        ...options.loader,
+        '.png': 'file'
+      }
+      options.publicPath = '/img/'
+      options.write = true
+
+      return options
+    }
+  })
+
+  const Component = getMDXComponent(code)
+
+  const {container} = render(React.createElement(Component))
+
+  assert.match(container.innerHTML, 'src="/img/150')
+
+  const error = /** @type Error */ (await bundleMDX(mdxSource, {
+    cwd: process.cwd(),
+    xdmOptions: (vFile, options) => {
+      options.remarkPlugins = [remarkMdxImages]
+
+      return options
+    },
+    esbuildOptions: (options) => {
+      options.loader = {
+        ...options.loader,
+        // esbuild will throw its own error if we try to use `file` loader without `outdir`
+        '.png': 'dataurl'
+      }
+      options.write = true
+
+      return options
+    }
+  }).catch(e => e))
+
+  assert.equal(
+    error.message,
+    "You must either specify `write: false` or `write: true` and `outdir: '/path'` in your esbuild options",
   )
 })
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -312,13 +312,13 @@ test('should output assets', async () => {
       options.outdir = path.join(process.cwd(), 'output')
       options.loader = {
         ...options.loader,
-        '.png': 'file'
+        '.png': 'file',
       }
       options.publicPath = '/img/'
       options.write = true
 
       return options
-    }
+    },
   })
 
   const Component = getMDXComponent(code)
@@ -334,16 +334,16 @@ test('should output assets', async () => {
 
       return options
     },
-    esbuildOptions: (options) => {
+    esbuildOptions: options => {
       options.loader = {
         ...options.loader,
         // esbuild will throw its own error if we try to use `file` loader without `outdir`
-        '.png': 'dataurl'
+        '.png': 'dataurl',
       }
       options.write = true
 
       return options
-    }
+    },
   }).catch(e => e))
 
   assert.equal(

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ async function bundleMDX(
 
   const bundled = await esbuild.build(buildOptions)
 
-  if(bundled.outputFiles){
+  if (bundled.outputFiles) {
     const decoder = new StringDecoder('utf8')
 
     const code = decoder.write(Buffer.from(bundled.outputFiles[0].contents))
@@ -163,8 +163,10 @@ async function bundleMDX(
     }
   }
 
-  if(buildOptions.outdir && buildOptions.write){
-    const code = await readFile(path.join(buildOptions.outdir, '_mdx_bundler_entry_point.js'))
+  if (buildOptions.outdir && buildOptions.write) {
+    const code = await readFile(
+      path.join(buildOptions.outdir, '_mdx_bundler_entry_point.js'),
+    )
 
     await unlink(path.join(buildOptions.outdir, '_mdx_bundler_entry_point.js'))
 
@@ -174,7 +176,9 @@ async function bundleMDX(
     }
   }
 
-  throw new Error("You must either specify `write: false` or `write: true` and `outdir: '/path'` in your esbuild options")
+  throw new Error(
+    "You must either specify `write: false` or `write: true` and `outdir: '/path'` in your esbuild options",
+  )
 }
 
 export {bundleMDX}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 import {StringDecoder} from 'string_decoder'
 import remarkFrontmatter from 'remark-frontmatter'
@@ -7,6 +8,8 @@ import * as esbuild from 'esbuild'
 import {NodeResolvePlugin} from '@esbuild-plugins/node-resolve'
 import {globalExternals} from '@fal-works/esbuild-plugin-global-externals'
 import dirnameMessedUp from './dirname-messed-up.cjs'
+
+const {readFile, unlink} = fs.promises
 
 /**
  *
@@ -149,14 +152,29 @@ async function bundleMDX(
 
   const bundled = await esbuild.build(buildOptions)
 
-  const decoder = new StringDecoder('utf8')
+  if(bundled.outputFiles){
+    const decoder = new StringDecoder('utf8')
 
-  const code = decoder.write(Buffer.from(bundled.outputFiles[0].contents))
+    const code = decoder.write(Buffer.from(bundled.outputFiles[0].contents))
 
-  return {
-    code: `${code};return Component.default;`,
-    frontmatter,
+    return {
+      code: `${code};return Component.default;`,
+      frontmatter,
+    }
   }
+
+  if(buildOptions.outdir && buildOptions.write){
+    const code = await readFile(path.join(buildOptions.outdir, '_mdx_bundler_entry_point.js'))
+
+    await unlink(path.join(buildOptions.outdir, '_mdx_bundler_entry_point.js'))
+
+    return {
+      code: `${code};return Component.default;`,
+      frontmatter,
+    }
+  }
+
+  throw new Error("You must either specify `write: false` or `write: true` and `outdir: '/path'` in your esbuild options")
 }
 
 export {bundleMDX}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,7 +8,7 @@ import type {Plugin, BuildOptions, Loader} from 'esbuild'
 import type {ModuleInfo} from '@fal-works/esbuild-plugin-global-externals'
 import type {VFileCompatible, CompileOptions} from 'xdm/lib/compile'
 
-type ESBuildOptions = BuildOptions & {write: false}
+type ESBuildOptions = BuildOptions
 
 type BundleMDXOptions = {
   /**


### PR DESCRIPTION
With #29 we can now co-locate images as per #26 but only using the `dataurl` loader. To output the files to another directory requires `write: true` in the esbuild options which breaks `mdx-bundler` as it doesn't get the bundles contents returned to it.

This PR adds support for `write: true` by having `mdx-bundler` read the outputted file and then delete it.

I've compiled this version and run it against my next.js site with great results! All the images get copied to the correct directory for Next.JS to serve as satatic assets.

```ts
const {code} = await bundleMDX(source, {
  cwd: directory, // /disk/path_/content/posts/slug
  xdmOptions: (input, options) => {
    options.remarkPlugins = [
      ...(options.remarkPlugins ?? []),
      remarkHighlight,
      remarkMdxImages
    ]
    
    return options
  },
  esbuildOptions: (options) => {
    options.outdir = path.join(process.cwd(), 'public', imagesUrl) // imagesUrl is /img/posts/slug
    options.loader = {
      ...options.loader,
      '.png': 'file',
      '.jpg': 'file',
      '.gif': 'file'
    }
    options.publicPath = imagesUrl
    options.write = true

    return options
  }
})
```

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
