### PR TITLE
feat: create our own xdm plugin that respects inMemory

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "cross-env": "^7.0.3",
     "kcd-scripts": "^10.0.0",
     "left-pad": "^1.3.0",
+    "mdx-test-data": "^1.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark-mdx-images": "^1.0.2",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -390,4 +390,16 @@ test('should output assets', async () => {
   )
 })
 
+test('should support mdx from node_modules', async () => {
+  const mdxSource = `
+import mdxData from 'mdx-test-data'
+
+Local Content
+
+<mdxData />
+  `.trim()
+
+  const {code} = await bundleMDX(mdxSource, {})
+})
+
 test.run()


### PR DESCRIPTION
Big thanks to @gaelhameon for the issue #41 and the code in there that helped me with esbuild! I've added you as a co-author as your fix in #41 was needed here.

Let me know what you think of the code in this PR.

What this does it removes the xdm parsing from `inMemoryPlugin` and puts it into its own plugin. This new plugin can read mdx from the disk and node_moudles fixing #41 and means that there is no need for users to configure xdm for disk files as its all going through one parser now.

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
