### PR TITLE
Pr/fix importing mdx from node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "cross-env": "^7.0.3",
     "kcd-scripts": "^10.0.0",
     "left-pad": "^1.3.0",
+    "mdx-test-data": "^1.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark-mdx-images": "^1.0.2",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -112,6 +112,23 @@ title: This is frontmatter
   )
 })
 
+test('bundles mdx files from node_modules', async () => {
+  const mdxSource = `
+import MdxTestData from 'mdx-test-data'
+
+The content below was imported from an MDX File in node_modules.
+
+<MdxTestData />
+  `.trim()
+
+  const result = await bundleMDX(mdxSource, {
+    files: {},
+  })
+
+  const Component = getMDXComponent(result.code)
+  render(React.createElement(Component))
+})
+
 test('bundles 3rd party deps', async () => {
   const mdxSource = `
 import Demo from './demo'

--- a/src/index.js
+++ b/src/index.js
@@ -70,14 +70,14 @@ async function bundleMDX(
             return {path: fullModulePath, pluginData: {inMemory: true}}
         }
 
-        // Return an empty object so that esbuild will handle resolving the file itself.
-        return {}
+        // Return undefined so that esbuild will handle resolving the file itself.
+        return undefined
       })
 
       build.onLoad({filter: /.*/}, async ({path: filePath, pluginData}) => {
         if (pluginData === undefined || !pluginData.inMemory) {
-          // Return an empty object so that esbuild will load & parse the file contents itself.
-          return {}
+          // Return undefined so that esbuild will load & parse the file contents itself.
+          return undefined
         }
 
         // the || .js allows people to exclude a file extension


### PR DESCRIPTION
**What**: return `undefined` instead of `{}` when inMemoryPlugin doesn't handle the file, to actually let esbuild (or other plugins) handle the file. Solves #41 

**Why**: the esbuild doc is kind of confusing, but empirical evidence suggests that returning `{}` doesn't allow other plugins or esbuild itself to try and resolve/load the file

**How**: replace `{}` by `undefined` where necessary

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
