### PR TITLE
fix: make esbuild a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,20 @@ It has more features, fewer bugs, and no runtime!
 
 </details>
 
+<details>
+  <summary>
+    <strong>
+      "Why is esbuild a peer dependancy?"
+    </strong>
+  </summary>
+
+esbuild provides a service written in GO that it interacts with. Only one
+instance of this service can run at a time and it must have an identical version
+to the npm package. If it was a hard dependency you would only be able to use
+the esbuild version mdx-bundler uses.
+
+</details>
+
 ## Table of Contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/package.json
+++ b/package.json
@@ -43,16 +43,18 @@
     "@babel/runtime": "^7.14.6",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@fal-works/esbuild-plugin-global-externals": "^2.1.1",
-    "esbuild": "^0.12.11",
     "gray-matter": "^4.0.3",
     "remark-frontmatter": "^3.0.0",
     "remark-mdx-frontmatter": "^1.0.1",
     "xdm": "^1.11.1"
   },
+  "peerDependencies": {
+    "esbuild": "0.11.x || 0.12.x"
+  },
   "devDependencies": {
     "@testing-library/react": "^12.0.0",
     "@types/jsdom": "^16.2.12",
-    "@types/react": "^17.0.11",
+    "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "cross-env": "^7.0.3",
     "jsdom": "^16.6.0",
@@ -62,7 +64,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark-mdx-images": "^1.0.2",
-    "typescript": "^4.3.4",
+    "typescript": "^4.3.5",
     "uvu": "^0.5.1"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "cross-env": "^7.0.3",
+    "esbuild": "^0.12.15",
     "jsdom": "^16.6.0",
     "kcd-scripts": "^11.1.0",
     "left-pad": "^1.3.0",


### PR DESCRIPTION
Had it reported that esbuild can't handle multiple versions within a project. The service starts up with node and then runs the whole time. esbuild throws an exception if the service and the npm package have different versions. 

Essentially if we have esbuild as a dependency we are forcing anyone using mdx-bundler to use our version of esbuild. Using a peer dependency should sort this.

I've gone for `0.11.x || 0.12.x` as the matcher as whilst esbuild is pre 1.0.0 npm treats each minor release as a major release. Once it hits 1.0.0 we can change to `^1.0.0` and leave it.

We will have to keep an eye on this going forwards to make sure we add in 0.13.x when it comes along. Is there a way to automate this and run our tests against multiple esbuild versions?

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
