### PR TITLE
feat: add react-dom support

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -446,4 +446,35 @@ test('should support over-riding the entry point', async () => {
   assert.match(container.innerHTML, 'Thanks for being willing to contribute')
 })
 
+test('should work with react-dom api', async () => {
+  const mdxSource = `
+import Demo from './demo'
+
+<Demo />
+  `.trim()
+  
+  const result = await bundleMDX(mdxSource, {
+    files: {
+      './demo.tsx': `
+import * as ReactDOM from 'react-dom'
+
+function Demo() {
+  return ReactDOM.createPortal(
+    <div>Portal!</div>,
+    document.body
+  )
+}
+
+export default Demo
+`.trim()
+    }
+  })
+
+  const Component = getMDXComponent(result.code)
+
+  const {container} = render(React.createElement(Component), { container: document.body })
+
+  assert.match(container.innerHTML, 'Portal!')
+})
+
 test.run()

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as _jsx_runtime from 'react/jsx-runtime.js'
+import * as ReactDOM from 'react-dom'
 
 /**
  * @typedef {{[name: string]: React.ComponentType | string | ComponentMap}} ComponentMap
@@ -16,7 +17,7 @@ import * as _jsx_runtime from 'react/jsx-runtime.js'
  * @return {React.FunctionComponent<MDXContentProps>}
  */
 function getMDXComponent(code, globals) {
-  const scope = {React, _jsx_runtime, ...globals}
+  const scope = {React, ReactDOM, _jsx_runtime, ...globals}
   // eslint-disable-next-line
   const fn = new Function(...Object.keys(scope), code)
   return fn(...Object.values(scope))


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added support to ReactDOM API.


<!-- Why are these changes necessary? -->

**Why**:

Today we receive an error when using something like `ReactDOM.createPortal`.

![image](https://user-images.githubusercontent.com/32134586/125152608-faa2a480-e123-11eb-9902-aaf61e15f50b.png)

Some fallback is to use the `globals` from `getMDXComponent`:
```jsx
import * as ReactDOM from 'react-dom'

getMDXComponent(code, { ReactDOM })
```

As `react-dom` is part of `react` API, I think it'll be good to be built-in in `mdx-bundler`.

<!-- How were these changes implemented? -->

**How**:

Added `react-dom` inside `mdx-bundler/client`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
