### PR TITLE
fix: pass cwd to node-resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ This module is distributed via [npm][npm] which is bundled with [node][node] and
 should be installed as one of your project's `dependencies`:
 
 ```
-npm install --save mdx-bundler
+npm install --save mdx-bundler esbuild
 ```
 
 One of mdx-bundler's dependancies requires a working [node-gyp][node-gyp] setup

--- a/package.json
+++ b/package.json
@@ -42,20 +42,20 @@
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@esbuild-plugins/node-resolve": "^0.1.4",
-    "@fal-works/esbuild-plugin-global-externals": "^2.1.1",
+    "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
     "gray-matter": "^4.0.3",
     "remark-frontmatter": "^3.0.0",
     "remark-mdx-frontmatter": "^1.0.1",
-    "xdm": "^1.11.1"
+    "xdm": "^1.12.1"
   },
   "peerDependencies": {
     "esbuild": "0.11.x || 0.12.x"
   },
   "devDependencies": {
     "@testing-library/react": "^12.0.0",
-    "@types/jsdom": "^16.2.12",
-    "@types/react": "^17.0.13",
-    "@types/react-dom": "^17.0.8",
+    "@types/jsdom": "^16.2.13",
+    "@types/react": "^17.0.14",
+    "@types/react-dom": "^17.0.9",
     "cross-env": "^7.0.3",
     "esbuild": "^0.12.15",
     "jsdom": "^16.6.0",
@@ -64,7 +64,7 @@
     "mdx-test-data": "^1.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remark-mdx-images": "^1.0.2",
+    "remark-mdx-images": "^1.0.3",
     "typescript": "^4.3.5",
     "uvu": "^0.5.1"
   },

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -152,7 +152,7 @@ import Demo from './demo'
   assert.equal(
     error.message,
     `Build failed with 1 error:
-__mdx_bundler_fake_dir__/_mdx_bundler_entry_point.mdx:3:17: error: Could not resolve "./demo"`,
+_mdx_bundler_entry_point.mdx:3:17: error: Could not resolve "./demo"`,
   )
 })
 
@@ -174,7 +174,7 @@ import Demo from './demo'
   assert.equal(
     error.message,
     `Build failed with 1 error:
-__mdx_bundler_fake_dir__/demo.tsx:1:7: error: Could not resolve "./blah-blah"`,
+demo.tsx:1:7: error: Could not resolve "./blah-blah"`,
   )
 })
 
@@ -196,7 +196,7 @@ import Demo from './demo.blah'
   assert.equal(
     error.message,
     `Build failed with 1 error:
-__mdx_bundler_fake_dir__/_mdx_bundler_entry_point.mdx:3:17: error: [plugin: inMemory] Invalid loader: "blah" (valid: js, jsx, ts, tsx, css, json, text, base64, dataurl, file, binary)`,
+_mdx_bundler_entry_point.mdx:3:17: error: [plugin: inMemory] Invalid loader: "blah" (valid: js, jsx, ts, tsx, css, json, text, base64, dataurl, file, binary)`,
   )
 })
 
@@ -343,11 +343,11 @@ test('should output assets', async () => {
   const mdxSource = `
 # Sample Post
 
-![Sample Image](./other/150.png)
+![Sample Image](./150.png)
   `.trim()
 
   const {code} = await bundleMDX(mdxSource, {
-    cwd: process.cwd(),
+    cwd: path.join(process.cwd(), 'other'),
     xdmOptions: options => {
       options.remarkPlugins = [remarkMdxImages]
 
@@ -374,7 +374,7 @@ test('should output assets', async () => {
 
   const error = /** @type Error */ (
     await bundleMDX(mdxSource, {
-      cwd: process.cwd(),
+      cwd: path.join(process.cwd(), 'other'),
       xdmOptions: options => {
         options.remarkPlugins = [remarkMdxImages]
 
@@ -452,7 +452,7 @@ import Demo from './demo'
 
 <Demo />
   `.trim()
-  
+
   const result = await bundleMDX(mdxSource, {
     files: {
       './demo.tsx': `
@@ -466,13 +466,15 @@ function Demo() {
 }
 
 export default Demo
-`.trim()
-    }
+`.trim(),
+    },
   })
 
   const Component = getMDXComponent(result.code)
 
-  const {container} = render(React.createElement(Component), { container: document.body })
+  const {container} = render(React.createElement(Component), {
+    container: document.body,
+  })
 
   assert.match(container.innerHTML, 'Portal!')
 })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -301,15 +301,15 @@ test('require from current directory', async () => {
   const mdxSource = `
 # Title
 
-import {Sample} from './other/sample-component'
+import {Sample} from './sample-component'
 
 <Sample />
 
-![A Sample Image](./other/150.png)
+![A Sample Image](./150.png)
 `.trim()
 
   const {code} = await bundleMDX(mdxSource, {
-    cwd: process.cwd(),
+    cwd: path.join(process.cwd(), 'other'),
     xdmOptions: options => {
       options.remarkPlugins = [remarkMdxImages]
 

--- a/src/index.js
+++ b/src/index.js
@@ -120,26 +120,6 @@ async function bundleMDX(
     },
   }
 
-  /** @type import('esbuild').Plugin */
-  const absRootPlugin = {
-    name: 'absRoot',
-    setup: ({onResolve}) => {
-      onResolve({filter: /.*/}, ({path: filePath, importer}) => {
-        const modulePath = path.resolve(path.dirname(importer), filePath)
-
-        if (
-          modulePath.includes('__mdx_bundler_fake_dir__') ||
-          modulePath === entryPath
-        ) {
-          return
-        }
-
-        // eslint-disable-next-line consistent-return
-        return {path: modulePath}
-      })
-    },
-  }
-
   const buildOptions = esbuildOptions({
     entryPoints: [entryPath],
     write: false,
@@ -164,8 +144,10 @@ async function bundleMDX(
         },
       }),
       // eslint-disable-next-line @babel/new-cap
-      NodeResolvePlugin({extensions: ['.js', '.ts', '.jsx', '.tsx']}),
-      absRootPlugin,
+      NodeResolvePlugin({
+        extensions: ['.js', '.ts', '.jsx', '.tsx'],
+        resolveOptions: {basedir: cwd},
+      }),
       inMemoryPlugin,
       xdmESBuild(
         xdmOptions({
@@ -192,6 +174,7 @@ async function bundleMDX(
     return {
       code: `${code};return Component.default;`,
       frontmatter,
+      errors: bundled.errors,
     }
   }
 
@@ -209,6 +192,7 @@ async function bundleMDX(
     return {
       code: `${code};return Component.default;`,
       frontmatter,
+      errors: bundled.errors,
     }
   }
 


### PR DESCRIPTION
As per #66 with 5.x relative imports with `cwd` aren't working. Looks to me like node-resolve or esbuild stopped passing the cwd in the same way. It is pre 1.0.0 so thats to be expected really. 

Tried a few things (hence the plugin I added and then removed) but all it needed in the end was the cwd passing to node resolve. I have updated the tests so that they use the `./other` folder as the cwd instead of `process.cwd()` as we where getting false positives because node-resolve defaulted to `process.cwd()`

This also adds an update to the global externals plugin (https://github.com/fal-works/esbuild-plugin-global-externals/pull/3) that was messing with our esbuild peer-dep. To that end I've had to add `esbuild` to the readme as it needs installing manually now.

I've thrown this version onto the dev version of my site and everything builds again.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
