### PR TITLE
fix: unique bundle names

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "gray-matter": "^4.0.3",
     "remark-frontmatter": "^3.0.0",
     "remark-mdx-frontmatter": "^1.0.1",
+    "uuid": "^8.3.2",
     "xdm": "^1.12.1"
   },
   "peerDependencies": {
@@ -56,6 +57,7 @@
     "@types/jsdom": "^16.2.13",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",
+    "@types/uuid": "^8.3.1",
     "cross-env": "^7.0.3",
     "esbuild": "^0.12.15",
     "jsdom": "^16.6.0",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -149,11 +149,7 @@ import Demo from './demo'
     }).catch(e => e)
   )
 
-  assert.equal(
-    error.message,
-    `Build failed with 1 error:
-_mdx_bundler_entry_point.mdx:3:17: error: Could not resolve "./demo"`,
-  )
+  assert.match(error.message, `error: Could not resolve "./demo"`)
 })
 
 test('gives a handy error when importing a module that cannot be found', async () => {
@@ -193,10 +189,9 @@ import Demo from './demo.blah'
     }).catch(e => e)
   )
 
-  assert.equal(
+  assert.match(
     error.message,
-    `Build failed with 1 error:
-_mdx_bundler_entry_point.mdx:3:17: error: [plugin: inMemory] Invalid loader: "blah" (valid: js, jsx, ts, tsx, css, json, text, base64, dataurl, file, binary)`,
+    `error: [plugin: inMemory] Invalid loader: "blah" (valid: js, jsx, ts, tsx, css, json, text, base64, dataurl, file, binary)`,
   )
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import matter from 'gray-matter'
 import * as esbuild from 'esbuild'
 import {NodeResolvePlugin} from '@esbuild-plugins/node-resolve'
 import {globalExternals} from '@fal-works/esbuild-plugin-global-externals'
+import {v4 as uuid} from 'uuid'
 import dirnameMessedUp from './dirname-messed-up.cjs'
 
 const {readFile, unlink} = fs.promises
@@ -41,7 +42,7 @@ async function bundleMDX(
   // extract the frontmatter
   const {data: frontmatter} = matter(mdxSource)
 
-  const entryPath = path.join(cwd, './_mdx_bundler_entry_point.mdx')
+  const entryPath = path.join(cwd, `./_mdx_bundler_entry_point-${uuid()}.mdx`)
 
   /** @type Record<string, string> */
   const absoluteFiles = {[entryPath]: mdxSource}


### PR DESCRIPTION
**What**:

Adds a uuid to the file name of the entry point.

**Why**:

I use `write: true` on my site to output the assets alongside the bundle. `mdx-bunder` reads this in and deletes it after that. Next.JS builds multiple pages at a time and because I use the same bundle on mulitple pages I occasionaly get errors because thread A deleted the file before thread B tried to read it.

Re-running the build tends to solve it but I've now had it crop up on Vercel so its causing deploy issues now.

**How**:

I've added a UUID to the entry points name so that each run gets a unique file name. This should stop conflicts.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I'm calling this a `fix` as its not really a new feature and although we are chaning file names it was internal anyway so shouldn't be a breaking change for anyone.

I've also changed the error tests to `match` instead of `equal` as I keep having to update them when esbuild/xdm/mdx-bundler changes a file name or prefix structure. (of course with a uuid in the name we could never do an `equal`)