### PR TITLE
fix: allow esbuild 0.13.x & bump other deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,17 +40,17 @@
     "validate": "kcd-scripts validate"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.3",
+    "@babel/runtime": "^7.15.4",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
     "gray-matter": "^4.0.3",
     "remark-frontmatter": "^4.0.0",
     "remark-mdx-frontmatter": "^1.0.1",
     "uuid": "^8.3.2",
-    "xdm": "^2.0.0"
+    "xdm": "^2.1.0"
   },
   "peerDependencies": {
-    "esbuild": "0.11.x || 0.12.x"
+    "esbuild": "0.11.x || 0.12.x || 0.13.x"
   },
   "devDependencies": {
     "@testing-library/react": "^12.0.0",
@@ -61,14 +61,14 @@
     "c8": "^7.8.0",
     "cross-env": "^7.0.3",
     "esbuild": "^0.12.20",
-    "jsdom": "^16.7.0",
+    "jsdom": "^17.0.0",
     "kcd-scripts": "^11.2.0",
     "left-pad": "^1.3.0",
     "mdx-test-data": "^1.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark-mdx-images": "^1.0.3",
-    "typescript": "^4.3.5",
+    "typescript": "^4.4.3",
     "uvu": "^0.5.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow installing this package when using esbuild@0.13
<!-- Why are these changes necessary? -->

**Why**:

fixes an npm error that occurs when using esbuild@0.13 
<!-- How were these changes implemented? -->

**How**:

- bump dependencies
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
