### PR TITLE
feat: allow accessing named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ the esbuild version mdx-bundler uses.
   - [Options](#options)
   - [Component Substitution](#component-substitution)
   - [Frontmatter and const](#frontmatter-and-const)
+  - [Accessing named exports](#accessing-named-exports)
+  - [Image Bundling](#image-bundling)
+  - [bundleMDXFile](#bundlemdxfile)
   - [Known Issues](#known-issues)
 - [Inspiration](#inspiration)
 - [Other Solutions](#other-solutions)
@@ -525,6 +528,36 @@ export const exampleImage = 'https://example.com/image.jpg'
 <img src={exampleImage} alt="Image alt text" />
 ```
 
+### Accessing named exports
+
+You can use `getMDXExport` instead of `getMDXComponent` to treat the mdx file as a module instead of just a component.
+It takes the same arguments that `getMDXComponent` does.
+
+```mdx
+---
+title: Example Post
+---
+
+export const toc = [
+  { depth: 1, value: 'The title' }
+]
+
+# The title
+```
+
+```js
+import * as React from 'react'
+import {getMDXExport} from 'mdx-bundler/client'
+
+function MDXPage({code}: {code: string}) {
+  const mdxExport = getMDXExport(code)
+  console.log(mdxExport.toc) // [ { depth: 1, value: 'The title' } ]
+
+  const Component = React.useMemo(() => mdxExport.default, [code])
+
+  return <Component />
+}
+```
 ### Image Bundling
 
 With the [cwd](#cwd) and the remark plugin

--- a/package.json
+++ b/package.json
@@ -44,32 +44,32 @@
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
     "gray-matter": "^4.0.3",
-    "remark-frontmatter": "^4.0.0",
+    "remark-frontmatter": "^4.0.1",
     "remark-mdx-frontmatter": "^1.0.1",
     "uuid": "^8.3.2",
-    "xdm": "^2.1.0"
+    "xdm": "^3.2.0"
   },
   "peerDependencies": {
     "esbuild": "0.11.x || 0.12.x || 0.13.x"
   },
   "devDependencies": {
-    "@testing-library/react": "^12.0.0",
+    "@testing-library/react": "^12.1.2",
     "@types/jsdom": "^16.2.13",
-    "@types/react": "^17.0.17",
-    "@types/react-dom": "^17.0.9",
+    "@types/react": "^17.0.34",
+    "@types/react-dom": "^17.0.11",
     "@types/uuid": "^8.3.1",
-    "c8": "^7.8.0",
+    "c8": "^7.10.0",
     "cross-env": "^7.0.3",
-    "esbuild": "^0.12.20",
-    "jsdom": "^17.0.0",
-    "kcd-scripts": "^11.2.0",
+    "esbuild": "^0.13.12",
+    "jsdom": "^18.0.1",
+    "kcd-scripts": "^11.2.2",
     "left-pad": "^1.3.0",
     "mdx-test-data": "^1.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark-mdx-images": "^1.0.3",
     "typescript": "^4.4.3",
-    "uvu": "^0.5.1"
+    "uvu": "^0.5.2"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -402,15 +402,12 @@ published: 2021-02-13
 description: This is some meta-data
 ---
 
-export const uncle = 'bob'
+export const uncle = 'Bob'
 
-# Bob was indeed the uncle
+# {uncle} was indeed the uncle
 `.trim()
 
   const result = await bundleMDX(mdxSource)
-  const frontmatter =
-  /** @type { title: string, description: string, published: string } */ result.frontmatter
-
   const exports = getMDXExport(result.code)
 
   // remark-mdx-frontmatter exports frontmatter
@@ -420,7 +417,7 @@ export const uncle = 'bob'
     description: 'This is some meta-data',
   })
 
-  assert.equal(exports.uncle, 'bob')
+  assert.equal(exports.uncle, 'Bob')
 
   const { container } = render(
     React.createElement(exports.default),

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -408,19 +408,19 @@ export const uncle = 'Bob'
 `.trim()
 
   const result = await bundleMDX(mdxSource)
-  const exports = getMDXExport(result.code)
+  const mdxExport = getMDXExport(result.code)
 
   // remark-mdx-frontmatter exports frontmatter
-  assert.equal(exports.frontmatter, {
+  assert.equal(mdxExport.frontmatter, {
     title: 'Example Post',
     published: new Date('2021-02-13'),
     description: 'This is some meta-data',
   })
 
-  assert.equal(exports.uncle, 'Bob')
+  assert.equal(mdxExport.uncle, 'Bob')
 
   const { container } = render(
-    React.createElement(exports.default),
+    React.createElement(mdxExport.default),
   )
   
   assert.equal(container.innerHTML, `<h1>Bob was indeed the uncle</h1>`)

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -408,6 +408,8 @@ export const uncle = 'Bob'
 `.trim()
 
   const result = await bundleMDX(mdxSource)
+
+  /** @type {import('../types').MDXExport<{uncle: string}, {title: string, published: Date, description: string}>} */
   const mdxExport = getMDXExport(result.code)
 
   // remark-mdx-frontmatter exports frontmatter
@@ -419,10 +421,8 @@ export const uncle = 'Bob'
 
   assert.equal(mdxExport.uncle, 'Bob')
 
-  const { container } = render(
-    React.createElement(mdxExport.default),
-  )
-  
+  const {container} = render(React.createElement(mdxExport.default))
+
   assert.equal(container.innerHTML, `<h1>Bob was indeed the uncle</h1>`)
 })
 

--- a/src/client.js
+++ b/src/client.js
@@ -18,18 +18,16 @@ import * as ReactDOM from 'react-dom'
  */
 function getMDXComponent(code, globals) {
   const mdxExport = getMDXExport(code, globals)
-  return mdxExport.default;
+  return mdxExport.default
 }
 
 /**
- *
+ * @template ExportedObject
+ * @template Frontmatter
+ * @type {import('./types').MDXExportFunction<ExportedObject, Frontmatter>}
  * @param {string} code - The string of code you got from bundleMDX
  * @param {Record<string, unknown>} [globals] - Any variables your MDX needs to have accessible when it runs
- * @return {{
-  *  default: React.FunctionComponent<MDXContentProps>, 
-  *  frontmatter: { [key: string]: unknown },
-  *  [key: string]: unknown
- * }}
+ *
  */
 function getMDXExport(code, globals) {
   const scope = {React, ReactDOM, _jsx_runtime, ...globals}

--- a/src/client.js
+++ b/src/client.js
@@ -17,8 +17,8 @@ import * as ReactDOM from 'react-dom'
  * @return {React.FunctionComponent<MDXContentProps>}
  */
 function getMDXComponent(code, globals) {
-  const exports = getMDXExport(code, globals)
-  return exports.default;
+  const mdxExport = getMDXExport(code, globals)
+  return mdxExport.default;
 }
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -17,10 +17,25 @@ import * as ReactDOM from 'react-dom'
  * @return {React.FunctionComponent<MDXContentProps>}
  */
 function getMDXComponent(code, globals) {
+  const exports = getMDXExport(code, globals)
+  return exports.default;
+}
+
+/**
+ *
+ * @param {string} code - The string of code you got from bundleMDX
+ * @param {Record<string, unknown>} [globals] - Any variables your MDX needs to have accessible when it runs
+ * @return {{
+  *  default: React.FunctionComponent<MDXContentProps>, 
+  *  frontmatter: { [key: string]: unknown },
+  *  [key: string]: unknown
+ * }}
+ */
+function getMDXExport(code, globals) {
   const scope = {React, ReactDOM, _jsx_runtime, ...globals}
   // eslint-disable-next-line
   const fn = new Function(...Object.keys(scope), code)
   return fn(...Object.values(scope))
 }
 
-export {getMDXComponent}
+export {getMDXComponent, getMDXExport}

--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@ async function bundleMDX(
     const code = decoder.write(Buffer.from(bundled.outputFiles[0].contents))
 
     return {
-      code: `${code};return Component.default;`,
+      code: `${code};return Component;`,
       frontmatter: matter.data,
       errors: bundled.errors,
       matter,
@@ -214,7 +214,7 @@ async function bundleMDX(
     await unlink(path.join(buildOptions.outdir, fileName))
 
     return {
-      code: `${code};return Component.default;`,
+      code: `${code};return Component`,
       frontmatter: matter.data,
       errors: bundled.errors,
       matter,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -136,3 +136,19 @@ type BundleMDXOptions = {
     options: GrayMatterOption<I, any>,
   ) => GrayMatterOption<I, any>
 }
+
+type MDXExport<
+  ExportObject extends {},
+  Frontmatter = {[key: string]: unknown},
+> = {
+  default: React.FunctionComponent<MDXContentProps>
+  frontmatter: Frontmatter
+} & ExportObject
+
+type MDXExportFunction<
+  ExportedObject extends {},
+  Frontmatter extends Record<string, unknown>,
+> = (
+  code: string,
+  globals?: Record<string, unknown>,
+) => MDXExport<ExportedObject, Frontmatter>


### PR DESCRIPTION

**What**: Fix for #108.

**Why**: The PR allows users to access named exports from mdx files which are added by a some remark plugins and in general promotes better interoperability between mdx and jsx

**How**: Removed `.default` in `bundleMDX` and moved it to 2 client side exports. Older users can stick to `getMDXComponent` without any breaking changes. Future users can opt to use `getMDXExport` if they need to access exports and the component is always available as the `default` export

```js
import * as React from 'react'
import {getMDXExport} from 'mdx-bundler/client'

function MDXPage({code}: {code: string}) {
  const mdxExport = getMDXExport(code)

  console.log(mdxExport.someExport)

  const Component = React.useMemo(() => mdxExport.default, [code])

  return <Component />
}
```
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I'm not very confident about the return type of `getMDXExport`. Could use some guidance on what would be the best return type or if we can refactor it into a generic type.