### PR TITLE
chore: add `esbuild` `0.14.x` to peerDependencies range

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "xdm": "^3.3.0"
   },
   "peerDependencies": {
-    "esbuild": "0.11.x || 0.12.x || 0.13.x"
+    "esbuild": "0.11.x || 0.12.x || 0.13.x || 0.14.x"
   },
   "devDependencies": {
     "@testing-library/react": "^12.1.2",


### PR DESCRIPTION
Part of https://github.com/kentcdodds/mdx-bundler/pull/62
appending a new matcher temporarily until it hits `1.0.0`.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add `esbuild` `0.14.x` as a matcher.

<!-- Why are these changes necessary? -->

**Why**:
Throws a warning in `yarn` 

<img width="1648" alt="pr-ss" src="https://user-images.githubusercontent.com/25561152/144293231-4839db03-7ae8-4594-991e-e56197a0b4ce.png">

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
