### PR TITLE
feat: support vfile input

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "gray-matter": "^4.0.3",
     "remark-frontmatter": "^4.0.1",
     "remark-mdx-frontmatter": "^1.1.1",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "vfile": "^5.3.2"
   },
   "peerDependencies": {
     "esbuild": "0.11.x || 0.12.x || 0.13.x || 0.14.x"

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -484,6 +484,20 @@ test('should support mdx from VFile', async () => {
   assert.is(container.innerHTML, '<h1>Heading</h1>')
 })
 
+test('should support mdx from VFile without path', async () => {
+  const mdxSource = `# Heading`
+
+  const vfile = new VFile({value: mdxSource})
+
+  const {code} = await bundleMDX({source: vfile})
+
+  const Component = getMDXComponent(code)
+
+  const {container} = render(React.createElement(Component))
+
+  assert.is(container.innerHTML, '<h1>Heading</h1>')
+})
+
 test('should provide VFile path to plugins', async () => {
   const mdxSource = `# Heading`
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,11 @@ async function bundleMDX({
     /** @type any */ // Slight type hack to get the graymatter front matter typed correctly.
     const gMatter = grayMatter(value, grayMatterOptions({}))
     matter = gMatter
-    entryPath = source.path ?? path.join(cwd, `./_mdx_bundler_entry_point-${uuid()}.mdx`)
+    entryPath = source.path
+      ? path.isAbsolute(source.path)
+        ? source.path
+        : path.join(source.cwd, source.path)
+      : path.join(cwd, `./_mdx_bundler_entry_point-${uuid()}.mdx`)
     absoluteFiles[entryPath] = value
   } else if (typeof file === 'string') {
     // The user has supplied a file.

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,11 @@ async function bundleMDX({
     )
   }
 
+  /** @type {(vfile: unknown) => vfile is import('vfile').VFile} */
+  function isVFile(vfile) {
+    return vfile !== null && typeof vfile === 'object' && 'value' in vfile && 'path' in vfile
+  }
+
   if (typeof source === 'string') {
     // The user has supplied MDX source.
     /** @type any */ // Slight type hack to get the graymatter front matter typed correctly.
@@ -63,6 +68,13 @@ async function bundleMDX({
     matter = gMatter
     entryPath = path.join(cwd, `./_mdx_bundler_entry_point-${uuid()}.mdx`)
     absoluteFiles[entryPath] = source
+  } else if (isVFile(source)) {
+    const value = String(source.value)
+    /** @type any */ // Slight type hack to get the graymatter front matter typed correctly.
+    const gMatter = grayMatter(value, grayMatterOptions({}))
+    matter = gMatter
+    entryPath = source.path
+    absoluteFiles[entryPath] = value
   } else if (typeof file === 'string') {
     // The user has supplied a file.
     /** @type any */ // Slight type hack to get the graymatter front matter typed correctly.

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ async function bundleMDX({
 
   /** @type {(vfile: unknown) => vfile is import('vfile').VFile} */
   function isVFile(vfile) {
-    return vfile !== null && typeof vfile === 'object' && 'value' in vfile && 'path' in vfile
+    return typeof vfile === 'object' && vfile !== null && 'value' in vfile
   }
 
   if (typeof source === 'string') {
@@ -73,7 +73,7 @@ async function bundleMDX({
     /** @type any */ // Slight type hack to get the graymatter front matter typed correctly.
     const gMatter = grayMatter(value, grayMatterOptions({}))
     matter = gMatter
-    entryPath = source.path
+    entryPath = source.path ?? path.join(cwd, `./_mdx_bundler_entry_point-${uuid()}.mdx`)
     absoluteFiles[entryPath] = value
   } else if (typeof file === 'string') {
     // The user has supplied a file.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,7 +8,7 @@ import type {Plugin, BuildOptions, Loader} from 'esbuild'
 import type {ModuleInfo} from '@fal-works/esbuild-plugin-global-externals'
 import type {ProcessorOptions} from '@mdx-js/esbuild/lib'
 import type {GrayMatterOption, Input, GrayMatterFile} from 'gray-matter'
-import type {VFile} from 'vfile'
+import type {VFile,VFileOptions} from 'vfile'
 
 type ESBuildOptions = BuildOptions
 
@@ -20,7 +20,7 @@ export type BundleMDXSource<Frontmatter> = {
   /**
    * Your MDX source.
    */
-  source: string | VFile
+  source: string | VFile | VFileOptions
   file?: undefined
 } & BundleMDXOptions<Frontmatter>
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,6 +8,7 @@ import type {Plugin, BuildOptions, Loader} from 'esbuild'
 import type {ModuleInfo} from '@fal-works/esbuild-plugin-global-externals'
 import type {ProcessorOptions} from '@mdx-js/esbuild/lib'
 import type {GrayMatterOption, Input, GrayMatterFile} from 'gray-matter'
+import type {VFile} from 'vfile'
 
 type ESBuildOptions = BuildOptions
 
@@ -19,7 +20,7 @@ export type BundleMDXSource<Frontmatter> = {
   /**
    * Your MDX source.
    */
-  source: string
+  source: string | VFile
   file?: undefined
 } & BundleMDXOptions<Frontmatter>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: support providing input `source` as `Vfile` with full `path`, which can be accessed by plugins on `vfile.path`

<!-- Why are these changes necessary? -->

**Why**: being able to pass input to a `unified` pipeline as `VFile` is expected to work in the ecosystem i think. also, providing `remark`/`rehype` plugins with an actual source file path can be useful.

<!-- How were these changes implemented? -->

**How**: see below

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
