### PR TITLE
feat: support esbuild@0.15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "esbuild": "0.11.x || 0.12.x || 0.13.x || 0.14.x"
+    "esbuild": "0.11.x || 0.12.x || 0.13.x || 0.14.x || 0.15.x"
   },
   "devDependencies": {
     "@testing-library/react": "^13.0.0",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add esbuild@0.15.x to the list of peer dependencies.

<!-- Why are these changes necessary? -->

**Why**: At the moment, npm install will fail when the version of esbuild included in the project is on
the latest minor version.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests (maybe n/a)
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I don't know how to test this. I haven't seen anything in the changelog that would indicate to me it wouldn't work, but then I don't know the internals. [The changelog](https://github.com/evanw/esbuild/releases/tag/v0.15.0) refers to backwards incompatible changes, but they are to do with moving to an internal implementation of Yarn's PlugnPlay algorithm. Any advice would be greatly appreciated.
