### PR TITLE
fix: add NODE_ENV to `define` only if it is set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,12 @@ async function bundleMDX({
     },
   }
 
+  /** @type import('esbuild').BuildOptions["define"] */
+  const define = {}
+  if (process.env.NODE_ENV !== undefined) {
+    define['process.env.NODE_ENV'] = JSON.stringify(process.env.NODE_ENV)
+  }
+
   const buildOptions = esbuildOptions(
     {
       entryPoints: [entryPath],
@@ -175,9 +181,7 @@ async function bundleMDX({
       outdir: isWriting ? bundleDirectory : undefined,
       publicPath: isWriting ? bundlePath : undefined,
       absWorkingDir: cwd,
-      define: {
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-      },
+      define,
       plugins: [
         globalExternals({
           ...globals,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

closes #205 

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: #205 

<!-- Why are these changes necessary? -->

**Why**: `esbuild` >= 0.16.0 forces that something passed via `define` is a string. This was introduced in v0.16.0, see section "Add additional validation of API parameters" of <https://github.com/evanw/esbuild/releases/tag/v0.16.0>.

<!-- How were these changes implemented? -->

**How**: `'process.env.NODE_ENV'` is only set in `define` from now on if it is not `undefined`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
  - Unfortunately I could not reproduce it via the tests in the repository, even if I updated the devDependency esbuild...  
  - But I patched it for my project with pnpm patch and it worked: <https://github.com/pkerschbaum/pkerschbaum-homepage/commit/93acaca872de7cffca31af5f6a859c14f46b9c2d>
- [x] Ready to be merged
  - Apart from the missing test, it is ready to be merged.
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
