### PR TITLE
fix: type error in options parameter of mdxOptions

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,7 +6,7 @@
 
 import type {Plugin, BuildOptions, Loader} from 'esbuild'
 import type {ModuleInfo} from '@fal-works/esbuild-plugin-global-externals'
-import type {ProcessorOptions} from '@mdx-js/esbuild/lib'
+import type {Options} from '@mdx-js/esbuild/lib'
 import type {GrayMatterOption, Input, GrayMatterFile} from 'gray-matter'
 import type {MDXComponents} from 'mdx/types'
 import type {VFile,VFileOptions} from 'vfile'
@@ -88,9 +88,9 @@ type BundleMDXOptions<Frontmatter> = {
    * ```
    */
   mdxOptions?: (
-    options: ProcessorOptions,
+    options: Options,
     frontmatter: Frontmatter,
-  ) => ProcessorOptions
+  ) => Options
   /**
    * This allows you to modify the built-in esbuild configuration. This can be
    * especially helpful for specifying the compilation target.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Change the type of the `options` parameter in the `mdxOptions` function from the original `ProcessorOptions` to `Option`, which is the [`CompileOptions`](https://mdxjs.com/packages/mdx/#compileoptions) type.

**Why**:
After upgrading the `@mdx-js` dependency to version 3.0, there have been some changes in the `Options` defined in `@mdx-js/esbuild/lib`. This change has made the previously used `ProcessorOptions` invalid, causing a type error for the `options` parameter when using `mdxOptions` in TypeScript.

**How**:
Read the doc about [`ProcessorOptions`](https://mdxjs.com/packages/mdx/#processoroptions) and [`CompileOptions`](https://mdxjs.com/packages/mdx/#compileoptions) and find that need to use `CompileOptions` here.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

`@mdx-js/esbuild/lib` exports `CompileOptions` and an equivalent type called `Options`. I'm not sure which one is more appropriate to use here. In this commit, I have chosen `Options`.
