### PR TITLE
fix: type error in options parameter of mdxOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mdx-test-data": "^1.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "remark-mdx-images": "^2.0.0",
+    "remark-mdx-images": "^3.0.0",
     "typescript": "^5.2.2",
     "uvu": "^0.5.6"
   },

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,7 +6,7 @@
 
 import type {Plugin, BuildOptions, Loader} from 'esbuild'
 import type {ModuleInfo} from '@fal-works/esbuild-plugin-global-externals'
-import type {ProcessorOptions} from '@mdx-js/esbuild/lib'
+import type {Options} from '@mdx-js/esbuild/lib'
 import type {GrayMatterOption, Input, GrayMatterFile} from 'gray-matter'
 import type {MDXComponents} from 'mdx/types'
 import type {VFile,VFileOptions} from 'vfile'
@@ -88,9 +88,9 @@ type BundleMDXOptions<Frontmatter> = {
    * ```
    */
   mdxOptions?: (
-    options: ProcessorOptions,
+    options: Options,
     frontmatter: Frontmatter,
-  ) => ProcessorOptions
+  ) => Options
   /**
    * This allows you to modify the built-in esbuild configuration. This can be
    * especially helpful for specifying the compilation target.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
     "target": "ES2020",
     "module": "ES2020",
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+    "lib": [
+      "ES2021.String"
+    ]
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What** & **Why**:
https://github.com/kentcdodds/mdx-bundler/pull/219#issuecomment-1894987818

It also contains a fix for the `remark-mdx-images` [type error](https://stackoverflow.com/questions/63616486/property-replaceall-does-not-exist-on-type-string). 

**How**:
Changed the type of the `option` parameter in the `mdxOptions` function. Updated the version of the dependency `remarkMdxImages` and the `tsconfig` to pass the tests.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
