### PR TITLE
Share custom components in nested MDX files

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,62 @@ Ultimately, this gets rendered (basically):
 </main>
 ```
 
+### Custom Components in Downstream Files
+
+To make sure custom components are accessible in downstream MDX files, you 
+can use the `MDXProvider` from `@mdx-js/react` to pass custom components
+to your nested imports.
+
+```
+npm install --save @mdx-js/react
+```
+
+```tsx
+const globals = {
+  '@mdx-js/react': {
+    varName: 'MdxJsReact',
+    namedExports: ['useMDXComponents'],
+    defaultExport: false,
+  },
+};
+const { code } = bundleMDX({
+  source,
+  globals,
+  mdxOptions(options: Record<string, any>) {
+      return {
+        ...options,
+        providerImportSource: '@mdx-js/react',
+      };
+  }
+});
+```
+
+From there, you send the `code` to your client, and then:
+
+```tsx
+import { MDXProvider, useMDXComponents } from '@mdx-js/react';
+const MDX_GLOBAL_CONFIG = {
+  MdxJsReact: {
+    useMDXComponents,
+  },
+};
+export const MDXComponent: React.FC<{
+  code: string;
+  frontmatter: Record<string, any>;
+}> = ({ code }) => {
+  const Component = useMemo(
+    () => getMDXComponent(code, MDX_GLOBAL_CONFIG),
+    [code],
+  );
+
+  return (
+    <MDXProvider components={{ Text: ({ children }) => <p>{children}</p> }}>
+      <Component />
+    </MDXProvider>
+  );
+};
+```
+
 ### Options
 
 #### source

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ the esbuild version mdx-bundler uses.
 
 - [Installation](#installation)
 - [Usage](#usage)
+  - [Custom Components in Downstream Files](#custom-components-in-downstream-files)
   - [Options](#options)
   - [Returns](#returns)
   - [Types](#types)


### PR DESCRIPTION
Closes #195 

**What**:

This pull request adds a Readme guide to make sure custom components are accessible in nested MDX files.

**Why**:

With the current behaviour, passing custom components to nested MDX files is leading to unexpected rendering issues. This solution and Readme guide allows to share custom components across the MDX structure. 

**How**:

- Adding a new section to the README.md file providing a step-by-step solution
- The solution uses `MDXProvider` from `@mdx-js/react`

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged

