### PR TITLE
fix(build): default NODE_ENV to production

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ async function bundleMDX({
       publicPath: isWriting ? bundlePath : undefined,
       absWorkingDir: cwd,
       define: {
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'production'),
       },
       plugins: [
         globalExternals({


### PR DESCRIPTION
Otherwise this gets set to the string "undefined" which helps nobody.
