### PR TITLE
test: re-enable all tests

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -417,7 +417,7 @@ test('should output assets', async () => {
   )
 })
 
-test.only('should support importing named exports', async () => {
+test('should support importing named exports', async () => {
   const mdxSource = `
 ---
 title: Example Post


### PR DESCRIPTION
**What**:
Ensure that all tests in test suite is ran.

**Why**:
Only `should support importing named exports` test was being run. Which means, any changes in future could potentially introduce bugs.

**How**:
Removed `.only` from ``should support importing named exports` test.

**Checklist**:

- [ ] Documentation - N/A
- [X] Tests
- [X] Ready to be merged

**Additional Comments**
Some of the changes on my other branch was able to slip through skipped tests. Once adjusted, it helped me find a much better approach to said changes.
