### PR TITLE
fix(jsx): explicit declare of typings

### DIFF
--- a/client/jsx.d.ts
+++ b/client/jsx.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/client/jsx' 

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,13 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {
-    "react": "./react.js",
-    "jsx": "./jsx.js"
+    "react": {
+      "types": "./react.d.ts",
+      "default": "./react.js"
+    },
+    "jsx": {
+      "types": "./jsx.d.ts",
+      "default": "./jsx.js"
+    }
   }
 }

--- a/client/react.d.ts
+++ b/client/react.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/client/react' 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -247,7 +247,7 @@ type MDXExport<
   ExportObject extends {},
   Frontmatter = {[key: string]: unknown},
 > = {
-  default: React.FunctionComponent<MDXContentProps>
+  default: (props: MDXContentProps) => JSX.Element,
   frontmatter: Frontmatter
 } & ExportObject
 


### PR DESCRIPTION
**What**:
Expose typings for typescript

**Why**:
So typescript can use it.

**How**:
Update package.json's typings declarations

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [X] Ready to be merged

---
Working example (assuming 10.2.0 is used after merge): https://github.com/honojs/examples/pull/223/files
