### PR TITLE
fix: test command

### DIFF
--- a/src/__tests__/setup-tests.js
+++ b/src/__tests__/setup-tests.js
@@ -19,8 +19,13 @@ function copyProps(src, target) {
 // @ts-expect-error TS2322 🤷‍♂️
 global.window = window
 global.document = window.document
-// @ts-expect-error TS2740 🤷‍♂️
-global.navigator = {userAgent: 'node.js'}
+
+Object.defineProperty(global, 'navigator', {
+  value: {userAgent: 'node.js'},
+  writable: true,
+  configurable: true
+})
+
 global.requestAnimationFrame = callback => setTimeout(callback, 0)
 global.cancelAnimationFrame = id => clearTimeout(id)
 copyProps(window, global)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
This PR fixes a type error that is shown in CI. It previously had a `ts-expect-error` comment above, but CI blocks you from being able to run the test or setup script following the `README.md` file.

I would like to contribute to this package and ensure that the tests added going forward are working 🙂 

<!-- Why are these changes necessary? -->

**Why**:
Without this change, we are unable to run the tests or other scripts, at least not on the environment and node version I am using (v22.14)

<!-- How were these changes implemented? -->

**How**:
I looked at a couple of posts online regarding this issue, which seems to be notorious. The solution uses `Object.defineProperty` to properly handle the getter-only navigator property, which seems to be the preferred JavaScript solution for this type of issue.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
      
 <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
 I believe so, but happy to discuss what might be a better approach

<!-- feel free to add additional comments -->

Issue stack trace:

```shell
jackshelton@MacBook-Pro mdx-bundler % npm run setup -s
[test] TypeError: Cannot set property navigator of #<Object> which has only a getter
[test]     at file:///Users/jackshelton/dev/open-source/mdx-bundler/src/__tests__/setup-tests.js:23:18
[test]     at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
[test]     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
[test]     at async Module.run (file:///Users/jackshelton/dev/open-source/mdx-bundler/node_modules/uvu/run/index.mjs:9:3)
[test]     at async /Users/jackshelton/dev/open-source/mdx-bundler/node_modules/uvu/bin.js:26:5
[test] ------------|---------|----------|---------|---------|-------------------
[test] File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
[test] ------------|---------|----------|---------|---------|-------------------
[test] All files   |   74.52 |      100 |       0 |   74.52 |                   
[test]  src        |   75.08 |      100 |       0 |   75.08 |                   
[test]   index.js  |   75.08 |      100 |       0 |   75.08 | 36-48,56-112      
[test]  src/client |   69.69 |      100 |       0 |   69.69 |                   
[test]   jsx.js    |   69.69 |      100 |       0 |   69.69 | 12-15,26-31       
[test] ------------|---------|----------|---------|---------|-------------------
[test] npm run test --silent -- --coverage exited with code 1
--> Sending SIGTERM to other processes..
[lint] npm run lint --silent exited with code SIGTERM
--> Sending SIGTERM to other processes..
[typecheck] npm run typecheck --silent exited with code SIGTERM
--> Sending SIGTERM to other processes..
[build] npm run build --silent exited with code SIGTERM
jackshelton@MacBook-Pro mdx-bundler % 
```

envinfo:
```shell
  System:
    OS: macOS 15.1
    CPU: (16) arm64 Apple M4 Max
    Memory: 7.58 GB / 48.00 GB
    Shell: 5.9 - /bin/zsh
  Binaries:
    Node: 22.14.0 - ~/.nvm/versions/node/v22.14.0/bin/node
    Yarn: 1.22.22 - /usr/local/bin/yarn
    npm: 10.9.2 - ~/.nvm/versions/node/v22.14.0/bin/npm
    pnpm: 10.7.0 - ~/.nvm/versions/node/v22.14.0/bin/pnpm
    bun: 1.1.7 - ~/.bun/bin/bun
  Managers:
    Cargo: 1.85.0 - ~/.cargo/bin/cargo
    Homebrew: 4.4.24 - /opt/homebrew/bin/brew
    pip3: 24.3.1 - /opt/homebrew/bin/pip3
    RubyGems: 3.0.3.1 - /usr/bin/gem
  Utilities:
    Make: 3.81 - /usr/bin/make
    GCC: 16.0.0 - /usr/bin/gcc
    Git: 2.39.5 - /usr/bin/git
    Clang: 16.0.0 - /usr/bin/clang
    FFmpeg: 7.1 - /opt/homebrew/bin/ffmpeg
    Curl: 8.7.1 - /usr/bin/curl
    OpenSSL: 3.4.0 - /opt/homebrew/bin/openssl
  Servers:
    Apache: 2.4.62 - /usr/sbin/apachectl
  Virtualization:
    Docker: 28.0.1 - /opt/homebrew/bin/docker
    Docker Compose: 2.33.1 - /opt/homebrew/bin/docker-compose
  SDKs:
    iOS SDK:
      Platforms: DriverKit 24.2, iOS 18.2, macOS 15.2, tvOS 18.2, visionOS 2.2, watchOS 11.2
  IDEs:
    Android Studio: 2024.2 AI-242.23339.11.2421.12700392
    VSCode: 0.48.2 - /usr/local/bin/code
    Vim: 9.0 - /usr/bin/vim
    Xcode: 16.2/16C5032a - /usr/bin/xcodebuild
  Languages:
    Bash: 3.2.57 - /bin/bash
    Perl: 5.34.1 - /usr/bin/perl
    Python3: 3.13.1 - /opt/homebrew/bin/python3
    Ruby: 2.6.10 - /usr/bin/ruby
    Rust: 1.85.0 - /Users/jackshelton/.cargo/bin/rustc
  Databases:
    SQLite: 3.43.2 - /usr/bin/sqlite3
  Browsers:
    Brave Browser: 127.1.68.141
    Chrome: 134.0.6998.166
    Safari: 18.1
   ```
